### PR TITLE
Don't return events that take place after the UNTIL date in an RRULE

### DIFF
--- a/src/Entity/CalendarItem.php
+++ b/src/Entity/CalendarItem.php
@@ -61,6 +61,11 @@ class CalendarItem
     protected $repeatCount;
 
     /**
+     * @var DateTime
+     */
+    protected $repeatEndDate;
+
+    /**
      * @var Calendar
      */
     protected $calendar;
@@ -330,6 +335,30 @@ class CalendarItem
     }
 
     /**
+     * Sets the repeat end date.
+     *
+     * @param DateTime $repeatEndDate
+     *
+     * @return $this;
+     */
+    public function setRepeatEndDate($repeatEndDate)
+    {
+        $this->repeatEndDate = $repeatEndDate;
+
+        return $this;
+    }
+
+    /**
+     * Returns the repeat end date.
+     *
+     * @return DateTime;
+     */
+    public function getRepeatEndDate()
+    {
+        return $this->repeatEndDate;
+    }
+
+    /**
      * Sets the calendar.
      *
      * @param Calendar $calendar
@@ -400,6 +429,10 @@ class CalendarItem
         if ($dateEnd === null) {
             $dateEnd = clone $dateStart;
             $dateEnd->add(new DateInterval('P1Y'));
+        }
+
+        if (($this->repeatEndDate !== null) && ($this->repeatEndDate < $dateEnd)) {
+        	$dateEnd = $this->repeatEndDate;
         }
 
         $repeatDates = $this->getRepeatDates();

--- a/src/Reader/IcalReader.php
+++ b/src/Reader/IcalReader.php
@@ -129,6 +129,7 @@ class IcalReader
         $calendarItem->setRepeatInterval($this->getRepeatInterval($data[0]));
         $calendarItem->setRepeatDays($this->getRepeatDays($data[0]));
         $calendarItem->setRepeatCount($this->getRepeatCount($data[0]));
+        $calendarItem->setRepeatEndDate($this->getRepeatEndDate($data[0]));
         $this->setRepeatExceptions($calendarItemData, $calendarItem);
     }
 
@@ -292,6 +293,24 @@ class IcalReader
         $repeatCount = (int) $data['extra']['COUNT'];
 
         return $repeatCount;
+    }
+
+    /**
+     * Returns the date the repeat rule stops.
+     *
+     * @param array $data
+     *
+     * @return DateTime
+     */
+    protected function getRepeatEndDate(array $data)
+    {
+        if (!isset($data['extra']['UNTIL'])) {
+            return null;
+        }
+
+        $repeatEndDate = new DateTime($data['extra']['UNTIL']);
+
+        return $repeatEndDate;
     }
 
     /**


### PR DESCRIPTION
Google Calendar sets the UNTIL field in RRULEs when a recurring event is removed from the calendar. The code didn't follow this and returned old entries in `Calendar::getEvents`.
