### PR TITLE
Update IcalWriter.php

### DIFF
--- a/src/Writer/IcalWriter.php
+++ b/src/Writer/IcalWriter.php
@@ -50,7 +50,7 @@ class IcalWriter
 
             $lines = array_merge($lines, [
                 'UID:'.sha1($event->getTitle()),
-                'DTSTAMP:'.$dateStart->format('U'),
+                'DTSTAMP:'.$dateStart->format('Ymd\THis\Z'),
                 'END:VEVENT',
             ]);
         }


### PR DESCRIPTION
For `DTSTAMP:1508976000`

Gives
```
Invalid DTSTAMP value, must be a date-time value near line # 6
Reference: 3.3.5. Date-Time
```

https://www.kanzaki.com/docs/ical/dtstamp.html